### PR TITLE
Fixed issue #54

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -307,6 +307,16 @@ class enrol_autoenrol_plugin extends enrol_plugin {
         $instance = $ue->enrolmentinstance;
         $params = $manager->get_moodlepage()->url->params();
         $params['ue'] = $ue->id;
+        if ($this->allow_manage($instance) && has_capability("enrol/{$instance->enrol}:manage", $context)) {
+            $url = new moodle_url('/enrol/editenrolment.php', $params);
+            $actions[] = new user_enrolment_action(
+                    new pix_icon('t/edit', ''), get_string('editenrolment', 'enrol'), $url,
+                    array(
+                      'class' => 'editenrollink',
+                      'rel' => $ue->id,
+                      'data-action' => ENROL_ACTION_EDIT
+                    ));
+        }
         if ($this->allow_unenrol_user($instance, $ue) && has_capability('enrol/autoenrol:unenrol', $context)) {
             $url = new moodle_url('/enrol/unenroluser.php', $params);
             $actions[] = new user_enrolment_action(


### PR DESCRIPTION
**Description:** This fixes issue #54. This allows editing of enrolment settings for a given user under the `status` heading of the participants list.

Suspending a user is usually done through the participants list of a course in the user's respective settings:
![image](https://github.com/catalyst/moodle-enrol_autoenrol/assets/65814885/2453bf57-dd5f-4978-8c05-580efb595fca)

However, this plugin does not implement the edit 'user enrolment action'. This PR adds this back to allow this.

**Standard enrolment actions:** https://github.com/moodle/moodle/blob/MOODLE_401_STABLE/lib/enrollib.php#L2851-L2862
